### PR TITLE
Update LiteDB version to 5.0.9 and expose available get/set properties of LiteDatabase

### DIFF
--- a/litedbasync/litedbasync.csproj
+++ b/litedbasync/litedbasync.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.3" />
+    <PackageReference Include="LiteDB" Version="5.0.9" />
   </ItemGroup>
 
 </Project>

--- a/litedbasynctest/Database/DateTime_Tests.cs
+++ b/litedbasynctest/Database/DateTime_Tests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LiteDB.Async.Test
+{
+    public class DateTime_Tests : IDisposable
+    {
+        readonly string _databasePath;
+        readonly LiteDatabaseAsync _db;
+
+        bool _disposed;
+
+        public DateTime_Tests()
+        {
+            _databasePath = Path.Combine(Path.GetTempPath(), $"litedbn-async-testing-{Path.GetRandomFileName()}.db");
+            _db = new LiteDatabaseAsync(_databasePath) { UtcDate = true };
+        }
+
+        [Fact]
+        public async Task TestCanRoundtripUtcDateTime()
+        {
+            var collection = _db.GetCollection<ThingThatHappened>();
+            var now = new DateTime(1979, 3, 19, 12, 00, 00, DateTimeKind.Utc);
+            var evt = new ThingThatHappened { Time = now };
+
+            var upsertResult = await collection.UpsertAsync(evt);
+            Assert.True(upsertResult);
+
+            var listResult = await collection.Query().ToListAsync();
+            Assert.Single(listResult);
+            var resultThing = listResult[0];
+            Assert.Equal(now, resultThing.Time);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || _disposed) return;
+
+            try
+            {
+                _db.Dispose();
+                File.Delete(_databasePath);
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/litedbasynctest/SimpleDatabaseTest.cs
+++ b/litedbasynctest/SimpleDatabaseTest.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using LiteDB.Async;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -82,7 +81,7 @@ namespace LiteDB.Async.Test
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
-            {      
+            {
                 _db.Dispose();
                 File.Delete(_databasePath);
             }

--- a/litedbasynctest/ThingThatHappened.cs
+++ b/litedbasynctest/ThingThatHappened.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace LiteDB.Async.Test
+{
+    public class ThingThatHappened
+    {
+        public DateTime Time { get; set; }
+    }
+}


### PR DESCRIPTION
Among these, UtcDate has special significance, because setting it to try is the only way you can unambiguously roundtrip `DateTime` values. Also, it aligns better with how MongoDB behaves out of the box.