### PR TITLE
Replace use of two ManualResetEvents by SemaphoreSlim and CancellationTokenSource

### DIFF
--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -10,10 +10,9 @@ namespace LiteDB.Async
     {
         private readonly LiteDatabase _liteDB;
         private readonly Thread _backgroundThread;
-        private readonly ManualResetEventSlim _newTaskArrived = new ManualResetEventSlim(false);
-        private readonly ManualResetEventSlim _shouldTerminate = new ManualResetEventSlim(false);
+        private readonly SemaphoreSlim _newTaskArrived = new SemaphoreSlim(initialCount: 0, maxCount: int.MaxValue);
+        private readonly CancellationTokenSource _shouldTerminate = new CancellationTokenSource();
         private readonly ConcurrentQueue<LiteAsyncDelegate> _queue = new ConcurrentQueue<LiteAsyncDelegate>();
-        private readonly object _queueLock = new object();
 
         /// <summary>
         /// Starts LiteDB database using a connection string for file system database
@@ -62,49 +61,41 @@ namespace LiteDB.Async
 
         private void BackgroundLoop()
         {
-            var waitHandles = new[] { _newTaskArrived.WaitHandle, _shouldTerminate.WaitHandle };
+            var terminationToken = _shouldTerminate.Token;
 
-            while (true)
+            try
             {
-                var triggerEvent = WaitHandle.WaitAny(waitHandles);
-                if (triggerEvent == 1)
+                while (!terminationToken.IsCancellationRequested)
                 {
-                    return;
+                    _newTaskArrived.Wait(terminationToken);
+
+                    if (!_queue.TryDequeue(out var function)) continue;
+
+                    function();
                 }
-
-                LiteAsyncDelegate function;
-
-                lock (_queueLock)
-                {
-                    if (!_queue.TryDequeue(out function))
-                    {
-                        // reset when queue is empty
-                        _newTaskArrived.Reset();
-                        continue;
-                    }
-                }
-
-                function();
+            }
+            catch (OperationCanceledException) when (terminationToken.IsCancellationRequested)
+            {
+                // it's OK, we're exiting
             }
         }
 
         internal void Enqueue<T>(TaskCompletionSource<T> tcs, LiteAsyncDelegate function)
         {
-            lock (_queueLock)
+            void Function()
             {
-                _queue.Enqueue(() =>
+                try
                 {
-                    try
-                    {
-                        function();
-                    }
-                    catch (Exception ex)
-                    {
-                        tcs.SetException(new LiteAsyncException("LiteDb encounter an error. Details in the inner exception.", ex));
-                    }
-                });
-                _newTaskArrived.Set();
+                    function();
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(new LiteAsyncException("LiteDb encounter an error. Details in the inner exception.", ex));
+                }
             }
+
+            _queue.Enqueue(Function);
+            _newTaskArrived.Release();
         }
 
         #region Collections
@@ -154,13 +145,20 @@ namespace LiteDB.Async
         }
 
         #endregion
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
-                _shouldTerminate.Set();
-                _backgroundThread.Join();
-                _liteDB.Dispose();
+                using (_liteDB)
+                using (_shouldTerminate)
+                using (_newTaskArrived)
+                {
+                    _shouldTerminate.Cancel();
+                    
+                    // give the thread 5 seconds to exit... must not block forever here
+                    _backgroundThread.Join(TimeSpan.FromSeconds(5));
+                }
             }
         }
 

--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -35,6 +35,12 @@ namespace LiteDB.Async
             _backgroundThread.Start();
         }
 
+        /// <summary>
+        /// Gets the underlying <see cref="ILiteDatabase"/>. Can be used to access methods like
+        /// <see cref="ILiteDatabase.Rebuild"/>, <see cref="ILiteDatabase.Checkpoint"/>, etc.
+        /// </summary>
+        public ILiteDatabase GetUnderlyingDatabase() => _liteDB;
+
         public bool UtcDate
         {
             get => _liteDB.UtcDate;

--- a/litedbasynctest/Database/Rebuild_Underlying_Database.cs
+++ b/litedbasynctest/Database/Rebuild_Underlying_Database.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using LiteDB;
+using LiteDB.Async;
+using LiteDB.Engine;
+using Tests.LiteDB.Async;
+using Xunit;
+
+namespace litedbasynctest.Database
+{
+    public class Rebuild_Underlying_Database
+    {
+        [Fact]
+        public async Task CanRebuildDatabaseWithCaseSensitiveCultureInvariantCollation()
+        {
+            using var file = new TempFile();
+            using var database = new LiteDatabaseAsync(file.Filename);
+
+            var collation = new Collation(CultureInfo.InvariantCulture.LCID, CompareOptions.Ordinal);
+            
+            database.GetUnderlyingDatabase().Rebuild(new RebuildOptions {Collation = collation});
+
+            var docs = database.GetCollection<BsonDocument>("test");
+
+            await docs.InsertAsync(new BsonDocument { { "_id", "some-key" } });
+            await docs.InsertAsync(new BsonDocument { { "_id", "some-KEY" } });
+        }
+    }
+}

--- a/litedbasynctest/SimpleBenchmark.cs
+++ b/litedbasynctest/SimpleBenchmark.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using LiteDB.Async;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.LiteDB.Async
+{
+    public class SimpleBenchmark
+    {
+        const int Iterations = 10;
+        const int InsertCount = 1000;
+        const int QueryCount = 1000;
+
+        readonly ITestOutputHelper _testOutputHelper;
+
+        public SimpleBenchmark(ITestOutputHelper testOutputHelper) => _testOutputHelper = testOutputHelper;
+
+        [Fact]
+        [Description("Simple benchmark to give an indication of comparable performance before/after removing work queue lock")]
+        public void TakeTime()
+        {
+            var measurements = Enumerable.Range(0, Iterations)
+                .Select(n => MeasureTime(iteration: n).GetAwaiter().GetResult())
+                .ToList();
+
+            var averageMilliseconds = measurements.Average(t => t.TotalMilliseconds);
+
+            _testOutputHelper.WriteLine($"Performed {InsertCount} inserts and {QueryCount} queries in {averageMilliseconds:0.0} ms on average");
+        }
+
+        async Task<TimeSpan> MeasureTime(int iteration)
+        {
+            using var tempFile = new TempFile();
+            using var db = new LiteDatabaseAsync(tempFile.Filename);
+
+            var collection = db.GetCollection<Something>();
+
+            _testOutputHelper.WriteLine($"Iteration {iteration}/{Iterations}");
+
+            var stopwatch = Stopwatch.StartNew();
+
+            foreach (var doc in Enumerable.Range(0, InsertCount).Select(n => new Something { Text = Guid.NewGuid().ToString() }))
+            {
+                await collection.InsertAsync(doc);
+            }
+
+            var randomStringToQueryBy = Guid.NewGuid().ToString();
+
+            for (var counter = 0; counter < QueryCount; counter++)
+            {
+                var @null = await collection.FindOneAsync(s => s.Text == randomStringToQueryBy);
+            }
+
+            return stopwatch.Elapsed;
+        }
+
+        class Something
+        {
+            public string Text { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
This obviates the need for the `_queueLock`, as the semaphore both acts as a lock and a "there's more work to do" signal.

Use of `CancellationTokenSource`/`CancellationToken` to signal thread exit seems more contemporary, AND it has the added benefit that the semaphore's wait can be interrupted by the cancellation token.

To see if this change affected performance, I made the simple benchmark test (`SimpleBenchmark`). Here are the results of running the test

BEFORE:
```
Performed 1000 inserts and 1000 queries in 1260,2 ms on average
```

and AFTER:
```
Performed 1000 inserts and 1000 queries in 1193,7 ms on average
```
Conclusion: Doesn't seem to have made any significant impact on performance.