### PR TITLE
Add ability to access underlying database

### DIFF
--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -36,6 +36,12 @@ namespace LiteDB.Async
             _backgroundThread.Start();
         }
 
+        /// <summary>
+        /// Gets the underlying <see cref="ILiteDatabase"/>. Can be used to access methods like
+        /// <see cref="ILiteDatabase.Rebuild"/>, <see cref="ILiteDatabase.Checkpoint"/>, etc.
+        /// </summary>
+        public ILiteDatabase GetUnderlyingDatabase() => _liteDB;
+
         public bool UtcDate
         {
             get => _liteDB.UtcDate;

--- a/litedbasynctest/Database/Rebuild_Underlying_Database.cs
+++ b/litedbasynctest/Database/Rebuild_Underlying_Database.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using System.Threading.Tasks;
+using LiteDB;
+using LiteDB.Async;
+using LiteDB.Engine;
+using Tests.LiteDB.Async;
+using Xunit;
+
+namespace litedbasynctest.Database
+{
+    public class Rebuild_Underlying_Database
+    {
+        [Fact]
+        public async Task CanRebuildDatabaseWithCaseSensitiveCultureInvariantCollation()
+        {
+            using var file = new TempFile();
+            using var database = new LiteDatabaseAsync(file.Filename);
+
+            var collation = new Collation(CultureInfo.InvariantCulture.LCID, CompareOptions.Ordinal);
+            
+            database.GetUnderlyingDatabase().Rebuild(new RebuildOptions {Collation = collation});
+
+            var docs = database.GetCollection<BsonDocument>("test");
+
+            await docs.InsertAsync(new BsonDocument { { "_id", "some-key" } });
+            await docs.InsertAsync(new BsonDocument { { "_id", "some-KEY" } });
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `GetUnderlyingDatabase` method to `LiteDatabaseAsync`, so that one can retrieve the wrapped `ILiteDatabase`.

This is useful, because `ILiteDatabase` exposes various operations not available otherwise – e.g. the ability to rebuild the database with another collation:
```csharp
var collation = new Collation(CultureInfo.InvariantCulture.LCID, CompareOptions.Ordinal);

database.GetUnderlyingDatabase().Rebuild(new RebuildOptions {Collation = collation});
```
this way providing a way to make the database's string comparisons case sensitive.