### PR TITLE
Feature/readonly props

### DIFF
--- a/litedbasync/Collections/Aggregate.cs
+++ b/litedbasync/Collections/Aggregate.cs
@@ -12,8 +12,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync()
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count());
             });
             return tcs.Task;
         }
@@ -24,8 +24,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync(BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count(predicate));
             });
             return tcs.Task;
         }
@@ -36,8 +36,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync(string predicate, BsonDocument parameters)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count(predicate, parameters));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count(predicate, parameters));
             });
             return tcs.Task;
 
@@ -49,8 +49,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync(Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count(predicate));
             });
             return tcs.Task;
         }
@@ -61,8 +61,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync(Query query)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count(query));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count(query));
             });
             return tcs.Task;
         }
@@ -73,8 +73,8 @@ namespace LiteDB.Async
         public Task<int> CountAsync(string predicate, params BsonValue[] args)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Count(predicate, args));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Count(predicate, args));
             });
             return tcs.Task;
         }
@@ -85,8 +85,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync()
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount());
             });
             return tcs.Task;
         }
@@ -97,8 +97,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync(BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount(predicate));
             });
             return tcs.Task;
         }
@@ -109,8 +109,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync(string predicate, BsonDocument parameters)
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount(predicate, parameters));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount(predicate, parameters));
             });
             return tcs.Task;
         }
@@ -121,8 +121,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync(string predicate, params BsonValue[] args)
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount(predicate, args));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount(predicate, args));
             });
             return tcs.Task;
         }
@@ -133,8 +133,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync(Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount(predicate));
             });
             return tcs.Task;
         }
@@ -145,8 +145,8 @@ namespace LiteDB.Async
         public Task<long> LongCountAsync(Query query)
         {
             var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().LongCount(query));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.LongCount(query));
             });
             return tcs.Task;
         }
@@ -157,8 +157,8 @@ namespace LiteDB.Async
         public Task<bool> ExistsAsync(BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Exists(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Exists(predicate));
             });
             return tcs.Task;
         }
@@ -169,8 +169,8 @@ namespace LiteDB.Async
         public Task<bool> ExistsAsync(string predicate, BsonDocument parameters)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Exists(predicate, parameters));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Exists(predicate, parameters));
             });
             return tcs.Task;
         }
@@ -181,8 +181,8 @@ namespace LiteDB.Async
         public Task<bool> ExistsAsync(string predicate, params BsonValue[] args)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Exists(predicate, args));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Exists(predicate, args));
             });
             return tcs.Task;
         }
@@ -193,8 +193,8 @@ namespace LiteDB.Async
         public Task<bool> ExistsAsync(Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Exists(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Exists(predicate));
             });
             return tcs.Task;
         }
@@ -205,8 +205,8 @@ namespace LiteDB.Async
         public Task<bool> ExistsAsync(Query query)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Exists(query));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Exists(query));
             });
             return tcs.Task;
         }
@@ -219,8 +219,8 @@ namespace LiteDB.Async
         public Task<BsonValue> MinAsync(BsonExpression keySelector)
         {
             var tcs = new TaskCompletionSource<BsonValue>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Min(keySelector));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Min(keySelector));
             });
             return tcs.Task;
         }
@@ -231,8 +231,8 @@ namespace LiteDB.Async
         public Task<BsonValue> MinAsync()
         {
             var tcs = new TaskCompletionSource<BsonValue>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Min());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Min());
             });
             return tcs.Task;
         }
@@ -243,8 +243,8 @@ namespace LiteDB.Async
         public Task<K> MinAsync<K>(Expression<Func<T, K>> keySelector)
         {
             var tcs = new TaskCompletionSource<K>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Min(keySelector));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Min(keySelector));
             });
             return tcs.Task;
         }
@@ -255,8 +255,8 @@ namespace LiteDB.Async
         public Task<BsonValue> MaxAsync(BsonExpression keySelector)
         {
             var tcs = new TaskCompletionSource<BsonValue>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Max(keySelector));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Max(keySelector));
             });
             return tcs.Task;
         }
@@ -267,8 +267,8 @@ namespace LiteDB.Async
         public Task<BsonValue> MaxAsync()
         {
             var tcs = new TaskCompletionSource<BsonValue>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Max());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Max());
             });
             return tcs.Task;
         }
@@ -279,8 +279,8 @@ namespace LiteDB.Async
         public Task<K> MaxAsync<K>(Expression<Func<T, K>> keySelector)
         {
             var tcs = new TaskCompletionSource<K>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Max(keySelector));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Max(keySelector));
             });
             return tcs.Task;
 

--- a/litedbasync/Collections/Delete.cs
+++ b/litedbasync/Collections/Delete.cs
@@ -12,8 +12,8 @@ namespace LiteDB.Async
         public Task<bool> DeleteAsync(BsonValue id)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Delete(id));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Delete(id));
             });
             return tcs.Task;
         }
@@ -24,8 +24,8 @@ namespace LiteDB.Async
         public Task<int> DeleteManyAsync(BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DeleteMany(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate));
             });
             return tcs.Task;
         }
@@ -36,8 +36,8 @@ namespace LiteDB.Async
         public Task<int> DeleteManyAsync(string predicate, BsonDocument parameters)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DeleteMany(predicate, parameters));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate, parameters));
             });
             return tcs.Task;
         }
@@ -48,8 +48,8 @@ namespace LiteDB.Async
         public Task<int> DeleteManyAsync(string predicate, params BsonValue[] args)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DeleteMany(predicate, args));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate, args));
             });
             return tcs.Task;
         }
@@ -60,8 +60,8 @@ namespace LiteDB.Async
         public Task<int> DeleteManyAsync(Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DeleteMany(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate));
             });
             return tcs.Task;
         }
@@ -72,8 +72,8 @@ namespace LiteDB.Async
         public Task<int> DeleteAllAsync()
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DeleteAll());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DeleteAll());
             });
             return tcs.Task;
         }

--- a/litedbasync/Collections/Find.cs
+++ b/litedbasync/Collections/Find.cs
@@ -15,8 +15,8 @@ namespace LiteDB.Async
         public Task<IEnumerable<T>> FindAsync(BsonExpression predicate, int skip = 0, int limit = int.MaxValue)
         {
             var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Find(predicate, skip, limit));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Find(predicate, skip, limit));
             });
             return tcs.Task;
         }
@@ -27,8 +27,8 @@ namespace LiteDB.Async
         public Task<IEnumerable<T>> FindAsync(Query query, int skip = 0, int limit = int.MaxValue)
         {
             var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Find(query, skip, limit));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Find(query, skip, limit));
             });
             return tcs.Task;
         }
@@ -39,8 +39,8 @@ namespace LiteDB.Async
         public Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue)
         {
             var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Find(predicate, skip, limit));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Find(predicate, skip, limit));
             });
             return tcs.Task;
         }
@@ -55,8 +55,8 @@ namespace LiteDB.Async
         public Task<T> FindByIdAsync(BsonValue id)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindById(id));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindById(id));
             });
             return tcs.Task;
         }
@@ -67,8 +67,8 @@ namespace LiteDB.Async
         public Task<T> FindOneAsync(BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindOne(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindOne(predicate));
             });
             return tcs.Task;
         }
@@ -79,8 +79,8 @@ namespace LiteDB.Async
         public Task<T> FindOneAsync(string predicate, BsonDocument parameters)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindOne(predicate, parameters));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindOne(predicate, parameters));
             });
             return tcs.Task;
         }
@@ -91,8 +91,8 @@ namespace LiteDB.Async
         public Task<T> FindOneAsync(BsonExpression predicate, params BsonValue[] args)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindOne(predicate, args));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindOne(predicate, args));
             });
             return tcs.Task;
         }
@@ -103,8 +103,8 @@ namespace LiteDB.Async
         public Task<T> FindOneAsync(Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindOne(predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindOne(predicate));
             });
             return tcs.Task;
         }
@@ -115,8 +115,8 @@ namespace LiteDB.Async
         public Task<T> FindOneAsync(Query query)
         {
             var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindOne(query));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindOne(query));
             });
             return tcs.Task;
         }
@@ -127,8 +127,8 @@ namespace LiteDB.Async
         public Task<IEnumerable<T>> FindAllAsync()
         {
             var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().FindAll());
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.FindAll());
             });
             return tcs.Task;
         }

--- a/litedbasync/Collections/Include.cs
+++ b/litedbasync/Collections/Include.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Async
         /// </summary>
         public ILiteCollectionAsync<T> Include<K>(Expression<Func<T, K>> keySelector)
         {
-            return new LiteCollectionAsync<T>(GetUnderlyingCollection().Include(keySelector), _liteDatabaseAsync);
+            return new LiteCollectionAsync<T>(UnderlyingCollection.Include(keySelector), Database);
         }
 
         /// <summary>
@@ -20,7 +20,7 @@ namespace LiteDB.Async
         /// </summary>
         public ILiteCollectionAsync<T> Include(BsonExpression keySelector)
         {
-            return new LiteCollectionAsync<T>(GetUnderlyingCollection().Include(keySelector), _liteDatabaseAsync);
+            return new LiteCollectionAsync<T>(UnderlyingCollection.Include(keySelector), Database);
         }
     }
 }

--- a/litedbasync/Collections/Index.cs
+++ b/litedbasync/Collections/Index.cs
@@ -15,8 +15,8 @@ namespace LiteDB.Async
         public Task<bool> EnsureIndexAsync(string name, BsonExpression expression, bool unique = false)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().EnsureIndex(name, expression, unique));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.EnsureIndex(name, expression, unique));
             });
             return tcs.Task;
         }
@@ -29,8 +29,8 @@ namespace LiteDB.Async
         public Task<bool> EnsureIndexAsync(BsonExpression expression, bool unique = false)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().EnsureIndex(expression, unique));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.EnsureIndex(expression, unique));
             });
             return tcs.Task;
         }
@@ -43,8 +43,8 @@ namespace LiteDB.Async
         public Task<bool> EnsureIndexAsync<K>(Expression<Func<T, K>> keySelector, bool unique = false)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().EnsureIndex(keySelector, unique));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.EnsureIndex(keySelector, unique));
             });
             return tcs.Task;
         }
@@ -58,8 +58,8 @@ namespace LiteDB.Async
         public Task<bool> EnsureIndexAsync<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().EnsureIndex<K>(keySelector, unique));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.EnsureIndex<K>(keySelector, unique));
             });
             return tcs.Task;
         }
@@ -70,8 +70,8 @@ namespace LiteDB.Async
         public Task<bool> DropIndexAsync(string name)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().DropIndex(name));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.DropIndex(name));
             });
             return tcs.Task;
         }

--- a/litedbasync/Collections/Insert.cs
+++ b/litedbasync/Collections/Insert.cs
@@ -11,8 +11,8 @@ namespace LiteDB.Async
         public Task<BsonValue> InsertAsync(T entity)
         {
             var tcs = new TaskCompletionSource<BsonValue>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Insert(entity));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Insert(entity));
             });
             return tcs.Task;
         }
@@ -23,8 +23,8 @@ namespace LiteDB.Async
         public Task InsertAsync(BsonValue id, T entity)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                GetUnderlyingCollection().Insert(id, entity);
+            Database.Enqueue(tcs, () => {
+                UnderlyingCollection.Insert(id, entity);
                 tcs.SetResult(true);
             });
             return tcs.Task;
@@ -36,8 +36,8 @@ namespace LiteDB.Async
         public Task<int> InsertAsync(IEnumerable<T> entities)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Insert(entities));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Insert(entities));
             });
             return tcs.Task;
         }
@@ -48,8 +48,8 @@ namespace LiteDB.Async
         public Task<int> InsertBulkAsync(IEnumerable<T> entities, int batchSize = 5000)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().InsertBulk(entities, batchSize));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.InsertBulk(entities, batchSize));
             });
             return tcs.Task;
         }

--- a/litedbasync/Collections/Update.cs
+++ b/litedbasync/Collections/Update.cs
@@ -13,8 +13,8 @@ namespace LiteDB.Async
         public Task<bool> UpdateAsync(T entity)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Update(entity));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Update(entity));
             });
             return tcs.Task;
 
@@ -26,8 +26,8 @@ namespace LiteDB.Async
         public Task<bool> UpdateAsync(BsonValue id, T entity)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Update(id, entity));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Update(id, entity));
             });
             return tcs.Task;
         }
@@ -38,8 +38,8 @@ namespace LiteDB.Async
         public Task<int> UpdateAsync(IEnumerable<T> entities)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Update(entities));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Update(entities));
             });
             return tcs.Task;
         }
@@ -51,8 +51,8 @@ namespace LiteDB.Async
         public Task<int> UpdateManyAsync(BsonExpression transform, BsonExpression predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().UpdateMany(transform, predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.UpdateMany(transform, predicate));
             });
             return tcs.Task;
         }
@@ -64,8 +64,8 @@ namespace LiteDB.Async
         public Task<int> UpdateManyAsync(Expression<Func<T, T>> extend, Expression<Func<T, bool>> predicate)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().UpdateMany(extend, predicate));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.UpdateMany(extend, predicate));
             });
             return tcs.Task;
         }

--- a/litedbasync/Collections/Upsert.cs
+++ b/litedbasync/Collections/Upsert.cs
@@ -11,8 +11,8 @@ namespace LiteDB.Async
         public Task<bool> UpsertAsync(T entity)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Upsert(entity));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Upsert(entity));
             });
             return tcs.Task;
         }
@@ -23,8 +23,8 @@ namespace LiteDB.Async
         public Task<int> UpsertAsync(IEnumerable<T> entities)
         {
             var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Upsert(entities));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Upsert(entities));
             });
             return tcs.Task;
         }
@@ -35,8 +35,8 @@ namespace LiteDB.Async
         public Task<bool> UpsertAsync(BsonValue id, T entity)
         {
             var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(GetUnderlyingCollection().Upsert(id, entity));
+            Database.Enqueue(tcs, () => {
+                tcs.SetResult(UnderlyingCollection.Upsert(id, entity));
             });
             return tcs.Task;
         }

--- a/litedbasync/ILiteDatabaseAsync.cs
+++ b/litedbasync/ILiteDatabaseAsync.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Threading;
-using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using System.IO;
 using System.Collections.Generic;
 using LiteDB.Engine;
 
@@ -48,6 +45,11 @@ namespace LiteDB.Async
         /// Returns a special collection for storage files/stream inside datafile. Use _files and _chunks collection names. FileId is implemented as string. Use "GetStorage" for custom options
         /// </summary>
         ILiteStorageAsync<string> FileStorage { get; }
+
+        /// <summary>
+        /// Gets the underlying <see cref="ILiteDatabase"/>. Useful to access various operations not exposed by <see cref="ILiteDatabaseAsync"/>
+        /// </summary>
+        ILiteDatabase UnderlyingDatabase { get; }
 
         /// <summary>
         /// Get new instance of Storage using custom FileId type, custom "_files" collection name and custom "_chunks" collection. LiteDB support multiples file storages (using different files/chunks collection names)

--- a/litedbasync/LiteCollectionAsync.cs
+++ b/litedbasync/LiteCollectionAsync.cs
@@ -5,53 +5,43 @@ namespace LiteDB.Async
     /// </summary>
     public partial class LiteCollectionAsync<T> : ILiteCollectionAsync<T>
     {
-        private readonly ILiteCollection<T> _liteCollection;
-        private readonly LiteDatabaseAsync _liteDatabaseAsync;
         internal LiteCollectionAsync(ILiteCollection<T> liteCollection, LiteDatabaseAsync liteDatabaseAsync)
         {
-            _liteCollection = liteCollection;
-            _liteDatabaseAsync = liteDatabaseAsync;
+            UnderlyingCollection = liteCollection;
+            Database = liteDatabaseAsync;
         }
 
         /// <summary>
         /// The database this collection belongs to
         /// </summary>
-        public LiteDatabaseAsync Database {
-            get
-            {
-                return _liteDatabaseAsync;
-            }
-        }
+        public LiteDatabaseAsync Database { get; }
 
         /// <summary>
         /// The underlying ILiteCollection we wrap
         /// </summary>
-        public ILiteCollection<T> GetUnderlyingCollection()
-        {
-            return _liteCollection;
-        }
+        public ILiteCollection<T> UnderlyingCollection { get; }
 
         /// <summary>
         /// Return a new LiteQueryableAsync to build more complex queries
         /// </summary>
         public ILiteQueryableAsync<T> Query()
         {
-            return new LiteQueryableAsync<T>(GetUnderlyingCollection().Query(), _liteDatabaseAsync);
+            return new LiteQueryableAsync<T>(UnderlyingCollection.Query(), Database);
         }
 
          /// <summary>
         /// Get collection name
         /// </summary>
-        public string Name => _liteCollection.Name;
+        public string Name => UnderlyingCollection.Name;
 
         /// <summary>
         /// Get collection auto id type
         /// </summary>
-        public BsonAutoId AutoId => _liteCollection.AutoId;
+        public BsonAutoId AutoId => UnderlyingCollection.AutoId;
 
         /// <summary>
         /// Getting entity mapper from current collection. Returns null if collection are BsonDocument type
         /// </summary>
-        public EntityMapper EntityMapper => _liteCollection.EntityMapper;
+        public EntityMapper EntityMapper => UnderlyingCollection.EntityMapper;
    }
 }


### PR DESCRIPTION
This PR adds a readonly `UnderlyingDatabase` property to `ILiteDatabaseAsync`, so that one can retrieve the wrapped `ILiteDatabase`.

This is useful, because `ILiteDatabase` exposes various operations not available otherwise – e.g. the ability to rebuild the database with another collation:
```csharp
var collation = new Collation(CultureInfo.InvariantCulture.LCID, CompareOptions.Ordinal);
var liteDatabase = database.UnderlyingDatabase;

liteDatabase.Rebuild(new RebuildOptions {Collation = collation});
```
this way providing a way to make the database's string comparisons case sensitive.