### PR TITLE
Added LiteDatabaseAsync constructor taking in a ConnectionString object

### DIFF
--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -29,6 +29,16 @@ namespace LiteDB.Async
         }
 
         /// <summary>
+        /// Starts LiteDB database using a connection string for file system database
+        /// </summary>
+        public LiteDatabaseAsync(ConnectionString connectionString, BsonMapper mapper = null)
+        {
+            UnderlyingDatabase = new LiteDatabase(connectionString, mapper);
+            _backgroundThread = new Thread(BackgroundLoop);
+            _backgroundThread.Start();
+        }
+
+        /// <summary>
         /// Starts LiteDB database using a generic Stream implementation (mostly MemoryStrem).
         /// Use another MemoryStrem as LOG file.
         /// </summary>

--- a/litedbasynctest/ConnectionStringObjectTest.cs
+++ b/litedbasynctest/ConnectionStringObjectTest.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using LiteDB;
+using LiteDB.Async;
+using Xunit;
+
+namespace Tests.LiteDB.Async
+{
+    public class ConnectionStringObjectTest : IDisposable
+    {
+        private readonly ConnectionString _connectionString;
+        private readonly LiteDatabaseAsync _db;
+        public ConnectionStringObjectTest()
+        {
+            _connectionString = new ConnectionString()
+            {
+                Filename = Path.Combine(Path.GetTempPath(), "litedbn-async-testing-" + Path.GetRandomFileName() + ".db"),
+                Connection = ConnectionType.Shared,
+                Password = "hunter2"
+            };
+            _db = new LiteDatabaseAsync(_connectionString);
+        }
+
+        [Fact]
+        public async Task TestCanUpsertAndGetList()
+        {
+            var collection = _db.GetCollection<SimplePerson>();
+
+            var person = new SimplePerson()
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "John",
+                LastName = "Smith"
+            };
+
+            var upsertResult = await collection.UpsertAsync(person);
+            Assert.True(upsertResult);
+
+            var listResult = await collection.Query().ToListAsync();
+            Assert.Single(listResult);
+            var resultPerson = listResult[0];
+            Assert.Equal(person.Id, resultPerson.Id);
+            Assert.Equal(person.FirstName, resultPerson.FirstName);
+            Assert.Equal(person.LastName, resultPerson.LastName);
+        }
+ 
+ 
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {      
+                _db.Dispose();
+                File.Delete(_connectionString.Filename);
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
Added LiteDatabaseAsync constructor taking in a ConnectionString object to be consistent with LiteDatabase constructor here:

https://github.com/mbdavid/LiteDB/blob/5ec64e5bd2453e506bd135ace1b1c0ab5717d3f5/LiteDB/Client/Database/LiteDatabase.cs#L43
