### PR TITLE
Fixes #18: Methods are completed on background thread if ConfigureAwait(false) is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,4 @@ MigrationBackup/
 # VS Code local settings
 .vscode/launch.json
 .vscode/tasks.json
+.idea/

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,3 +3,4 @@ Contributors to LiteDb.Async are listed here.
 Mark Lockett https://github.com/mlockett42
 Mogens Heller Grabe https://github.com/mookid8000
 Jacob Mojiwat https://github.com/jmojiwat
+Martin Kuckert https://github.com/MKuckert

--- a/litedbasync/Collections/Aggregate.cs
+++ b/litedbasync/Collections/Aggregate.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count());
         }
 
@@ -20,7 +20,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count(predicate));
         }
 
@@ -29,7 +29,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(string predicate, BsonDocument parameters)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count(predicate, parameters));
         }
 
@@ -38,7 +38,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count(predicate));
         }
 
@@ -47,7 +47,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(Query query)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count(query));
         }
 
@@ -56,7 +56,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(string predicate, params BsonValue[] args)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Count(predicate, args));
         }
 
@@ -65,7 +65,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount());
         }
 
@@ -74,7 +74,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount(predicate));
         }
 
@@ -83,7 +83,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(string predicate, BsonDocument parameters)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount(predicate, parameters));
         }
 
@@ -92,7 +92,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(string predicate, params BsonValue[] args)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount(predicate, args));
         }
 
@@ -101,7 +101,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount(predicate));
         }
 
@@ -110,7 +110,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(Query query)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.LongCount(query));
         }
 
@@ -119,7 +119,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Exists(predicate));
         }
 
@@ -128,7 +128,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(string predicate, BsonDocument parameters)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Exists(predicate, parameters));
         }
 
@@ -137,7 +137,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(string predicate, params BsonValue[] args)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Exists(predicate, args));
         }
 
@@ -146,7 +146,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Exists(predicate));
         }
 
@@ -155,7 +155,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(Query query)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Exists(query));
         }
 
@@ -166,7 +166,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MinAsync(BsonExpression keySelector)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Min(keySelector));
         }
 
@@ -175,7 +175,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MinAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Min());
         }
 
@@ -184,7 +184,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<K> MinAsync<K>(Expression<Func<T, K>> keySelector)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Min(keySelector));
         }
 
@@ -193,7 +193,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MaxAsync(BsonExpression keySelector)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Max(keySelector));
         }
 
@@ -202,7 +202,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MaxAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Max());
         }
 
@@ -211,7 +211,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<K> MaxAsync<K>(Expression<Func<T, K>> keySelector)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Max(keySelector));
         }
 

--- a/litedbasync/Collections/Aggregate.cs
+++ b/litedbasync/Collections/Aggregate.cs
@@ -11,11 +11,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync()
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count());
         }
 
         /// <summary>
@@ -23,11 +20,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count(predicate));
         }
 
         /// <summary>
@@ -35,12 +29,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count(predicate, parameters));
-            });
-            return tcs.Task;
-
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count(predicate, parameters));
         }
 
         /// <summary>
@@ -48,11 +38,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count(predicate));
         }
 
         /// <summary>
@@ -60,11 +47,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(Query query)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count(query));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count(query));
         }
 
         /// <summary>
@@ -72,11 +56,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync(string predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Count(predicate, args));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Count(predicate, args));
         }
 
         /// <summary>
@@ -84,11 +65,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync()
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount());
         }
 
         /// <summary>
@@ -96,11 +74,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount(predicate));
         }
 
         /// <summary>
@@ -108,11 +83,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount(predicate, parameters));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount(predicate, parameters));
         }
 
         /// <summary>
@@ -120,11 +92,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(string predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount(predicate, args));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount(predicate, args));
         }
 
         /// <summary>
@@ -132,11 +101,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount(predicate));
         }
 
         /// <summary>
@@ -144,11 +110,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync(Query query)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.LongCount(query));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.LongCount(query));
         }
 
         /// <summary>
@@ -156,11 +119,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Exists(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Exists(predicate));
         }
 
         /// <summary>
@@ -168,11 +128,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Exists(predicate, parameters));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Exists(predicate, parameters));
         }
 
         /// <summary>
@@ -180,11 +137,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(string predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Exists(predicate, args));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Exists(predicate, args));
         }
 
         /// <summary>
@@ -192,11 +146,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Exists(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Exists(predicate));
         }
 
         /// <summary>
@@ -204,11 +155,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(Query query)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Exists(query));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Exists(query));
         }
 
         #region Min/Max
@@ -218,11 +166,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MinAsync(BsonExpression keySelector)
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Min(keySelector));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Min(keySelector));
         }
 
         /// <summary>
@@ -230,11 +175,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MinAsync()
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Min());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Min());
         }
 
         /// <summary>
@@ -242,11 +184,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<K> MinAsync<K>(Expression<Func<T, K>> keySelector)
         {
-            var tcs = new TaskCompletionSource<K>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Min(keySelector));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Min(keySelector));
         }
 
         /// <summary>
@@ -254,11 +193,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MaxAsync(BsonExpression keySelector)
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Max(keySelector));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Max(keySelector));
         }
 
         /// <summary>
@@ -266,11 +202,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> MaxAsync()
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Max());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Max());
         }
 
         /// <summary>
@@ -278,13 +211,10 @@ namespace LiteDB.Async
         /// </summary>
         public Task<K> MaxAsync<K>(Expression<Func<T, K>> keySelector)
         {
-            var tcs = new TaskCompletionSource<K>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Max(keySelector));
-            });
-            return tcs.Task;
-
+            return Database.Enqueue(
+                () => UnderlyingCollection.Max(keySelector));
         }
+
         #endregion
     }
 }

--- a/litedbasync/Collections/Delete.cs
+++ b/litedbasync/Collections/Delete.cs
@@ -11,11 +11,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DeleteAsync(BsonValue id)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Delete(id));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Delete(id));
         }
 
         /// <summary>
@@ -23,11 +20,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DeleteMany(predicate));
         }
 
         /// <summary>
@@ -35,11 +29,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate, parameters));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DeleteMany(predicate, parameters));
         }
 
         /// <summary>
@@ -47,11 +38,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(string predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate, args));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DeleteMany(predicate, args));
         }
 
         /// <summary>
@@ -59,11 +47,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DeleteMany(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DeleteMany(predicate));
         }
  
          /// <summary>
@@ -71,11 +56,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteAllAsync()
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DeleteAll());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DeleteAll());
         }
    }
 }

--- a/litedbasync/Collections/Delete.cs
+++ b/litedbasync/Collections/Delete.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DeleteAsync(BsonValue id)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Delete(id));
         }
 
@@ -20,7 +20,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DeleteMany(predicate));
         }
 
@@ -29,7 +29,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(string predicate, BsonDocument parameters)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DeleteMany(predicate, parameters));
         }
 
@@ -38,7 +38,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(string predicate, params BsonValue[] args)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DeleteMany(predicate, args));
         }
 
@@ -47,7 +47,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteManyAsync(Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DeleteMany(predicate));
         }
  
@@ -56,7 +56,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> DeleteAllAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DeleteAll());
         }
    }

--- a/litedbasync/Collections/Find.cs
+++ b/litedbasync/Collections/Find.cs
@@ -14,11 +14,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(BsonExpression predicate, int skip = 0, int limit = int.MaxValue)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Find(predicate, skip, limit));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Find(predicate, skip, limit));
         }
 
         /// <summary>
@@ -26,11 +23,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(Query query, int skip = 0, int limit = int.MaxValue)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Find(query, skip, limit));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Find(query, skip, limit));
         }
 
         /// <summary>
@@ -38,11 +32,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Find(predicate, skip, limit));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Find(predicate, skip, limit));
         }
 
         #endregion
@@ -54,11 +45,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindByIdAsync(BsonValue id)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindById(id));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindById(id));
         }
 
         /// <summary>
@@ -66,11 +54,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindOne(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindOne(predicate));
         }
 
         /// <summary>
@@ -78,11 +63,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindOne(predicate, parameters));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindOne(predicate, parameters));
         }
 
         /// <summary>
@@ -90,11 +72,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(BsonExpression predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindOne(predicate, args));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindOne(predicate, args));
         }
 
         /// <summary>
@@ -102,11 +81,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindOne(predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindOne(predicate));
         }
 
         /// <summary>
@@ -114,11 +90,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(Query query)
         {
-            var tcs = new TaskCompletionSource<T>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindOne(query));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindOne(query));
         }
 
         /// <summary>
@@ -126,11 +99,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAllAsync()
         {
-            var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.FindAll());
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.FindAll());
         }
 
         #endregion

--- a/litedbasync/Collections/Find.cs
+++ b/litedbasync/Collections/Find.cs
@@ -14,7 +14,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(BsonExpression predicate, int skip = 0, int limit = int.MaxValue)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Find(predicate, skip, limit));
         }
 
@@ -23,7 +23,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(Query query, int skip = 0, int limit = int.MaxValue)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Find(query, skip, limit));
         }
 
@@ -32,7 +32,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Find(predicate, skip, limit));
         }
 
@@ -45,7 +45,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindByIdAsync(BsonValue id)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindById(id));
         }
 
@@ -54,7 +54,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindOne(predicate));
         }
 
@@ -63,7 +63,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(string predicate, BsonDocument parameters)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindOne(predicate, parameters));
         }
 
@@ -72,7 +72,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(BsonExpression predicate, params BsonValue[] args)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindOne(predicate, args));
         }
 
@@ -81,7 +81,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindOne(predicate));
         }
 
@@ -90,7 +90,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FindOneAsync(Query query)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindOne(query));
         }
 
@@ -99,7 +99,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> FindAllAsync()
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.FindAll());
         }
 

--- a/litedbasync/Collections/Index.cs
+++ b/litedbasync/Collections/Index.cs
@@ -14,7 +14,7 @@ namespace LiteDB.Async
         /// <param name="unique">If is a unique index</param>
         public Task<bool> EnsureIndexAsync(string name, BsonExpression expression, bool unique = false)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.EnsureIndex(name, expression, unique));
         }
 
@@ -25,7 +25,7 @@ namespace LiteDB.Async
         /// <param name="unique">If is a unique index</param>
         public Task<bool> EnsureIndexAsync(BsonExpression expression, bool unique = false)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.EnsureIndex(expression, unique));
         }
 
@@ -36,7 +36,7 @@ namespace LiteDB.Async
         /// <param name="unique">Create a unique keys index?</param>
         public Task<bool> EnsureIndexAsync<K>(Expression<Func<T, K>> keySelector, bool unique = false)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.EnsureIndex(keySelector, unique));
         }
 
@@ -48,7 +48,7 @@ namespace LiteDB.Async
         /// <param name="unique">Create a unique keys index?</param>
         public Task<bool> EnsureIndexAsync<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.EnsureIndex<K>(name, keySelector, unique));
         }
 
@@ -57,7 +57,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DropIndexAsync(string name)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.DropIndex(name));
         }
     }

--- a/litedbasync/Collections/Index.cs
+++ b/litedbasync/Collections/Index.cs
@@ -14,11 +14,8 @@ namespace LiteDB.Async
         /// <param name="unique">If is a unique index</param>
         public Task<bool> EnsureIndexAsync(string name, BsonExpression expression, bool unique = false)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.EnsureIndex(name, expression, unique));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.EnsureIndex(name, expression, unique));
         }
 
         /// <summary>
@@ -28,11 +25,8 @@ namespace LiteDB.Async
         /// <param name="unique">If is a unique index</param>
         public Task<bool> EnsureIndexAsync(BsonExpression expression, bool unique = false)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.EnsureIndex(expression, unique));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.EnsureIndex(expression, unique));
         }
 
         /// <summary>
@@ -42,11 +36,8 @@ namespace LiteDB.Async
         /// <param name="unique">Create a unique keys index?</param>
         public Task<bool> EnsureIndexAsync<K>(Expression<Func<T, K>> keySelector, bool unique = false)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.EnsureIndex(keySelector, unique));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.EnsureIndex(keySelector, unique));
         }
 
         /// <summary>
@@ -57,11 +48,8 @@ namespace LiteDB.Async
         /// <param name="unique">Create a unique keys index?</param>
         public Task<bool> EnsureIndexAsync<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.EnsureIndex<K>(name, keySelector, unique));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.EnsureIndex<K>(name, keySelector, unique));
         }
 
         /// <summary>
@@ -69,11 +57,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DropIndexAsync(string name)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.DropIndex(name));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.DropIndex(name));
         }
     }
 }

--- a/litedbasync/Collections/Insert.cs
+++ b/litedbasync/Collections/Insert.cs
@@ -10,7 +10,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> InsertAsync(T entity)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Insert(entity));
         }
 
@@ -19,7 +19,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task InsertAsync(BsonValue id, T entity)
         {
-            return Database.Enqueue(() => {
+            return Database.EnqueueAsync(() => {
                 UnderlyingCollection.Insert(id, entity);
                 return true;
             });
@@ -30,7 +30,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> InsertAsync(IEnumerable<T> entities)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Insert(entities));
         }
 
@@ -39,7 +39,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> InsertBulkAsync(IEnumerable<T> entities, int batchSize = 5000)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.InsertBulk(entities, batchSize));
         }
     }

--- a/litedbasync/Collections/Insert.cs
+++ b/litedbasync/Collections/Insert.cs
@@ -10,11 +10,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> InsertAsync(T entity)
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Insert(entity));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Insert(entity));
         }
 
         /// <summary>
@@ -22,12 +19,10 @@ namespace LiteDB.Async
         /// </summary>
         public Task InsertAsync(BsonValue id, T entity)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
+            return Database.Enqueue(() => {
                 UnderlyingCollection.Insert(id, entity);
-                tcs.SetResult(true);
+                return true;
             });
-            return tcs.Task;
         }
 
         /// <summary>
@@ -35,11 +30,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> InsertAsync(IEnumerable<T> entities)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Insert(entities));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Insert(entities));
         }
 
         /// <summary>
@@ -47,11 +39,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> InsertBulkAsync(IEnumerable<T> entities, int batchSize = 5000)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.InsertBulk(entities, batchSize));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.InsertBulk(entities, batchSize));
         }
     }
 }

--- a/litedbasync/Collections/Update.cs
+++ b/litedbasync/Collections/Update.cs
@@ -12,7 +12,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpdateAsync(T entity)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Update(entity));
 
         }
@@ -22,7 +22,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpdateAsync(BsonValue id, T entity)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Update(id, entity));
         }
 
@@ -31,7 +31,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateAsync(IEnumerable<T> entities)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Update(entities));
         }
 
@@ -41,7 +41,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateManyAsync(BsonExpression transform, BsonExpression predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.UpdateMany(transform, predicate));
         }
 
@@ -51,7 +51,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateManyAsync(Expression<Func<T, T>> extend, Expression<Func<T, bool>> predicate)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.UpdateMany(extend, predicate));
         }
     }

--- a/litedbasync/Collections/Update.cs
+++ b/litedbasync/Collections/Update.cs
@@ -12,11 +12,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpdateAsync(T entity)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Update(entity));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Update(entity));
 
         }
 
@@ -25,11 +22,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpdateAsync(BsonValue id, T entity)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Update(id, entity));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Update(id, entity));
         }
 
         /// <summary>
@@ -37,11 +31,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateAsync(IEnumerable<T> entities)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Update(entities));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Update(entities));
         }
 
         /// <summary>
@@ -50,11 +41,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateManyAsync(BsonExpression transform, BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.UpdateMany(transform, predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.UpdateMany(transform, predicate));
         }
 
         /// <summary>
@@ -63,11 +51,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpdateManyAsync(Expression<Func<T, T>> extend, Expression<Func<T, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.UpdateMany(extend, predicate));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.UpdateMany(extend, predicate));
         }
     }
 }

--- a/litedbasync/Collections/Upsert.cs
+++ b/litedbasync/Collections/Upsert.cs
@@ -10,7 +10,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpsertAsync(T entity)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Upsert(entity));
         }
 
@@ -19,7 +19,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpsertAsync(IEnumerable<T> entities)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Upsert(entities));
         }
 
@@ -28,7 +28,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpsertAsync(BsonValue id, T entity)
         {
-            return Database.Enqueue(
+            return Database.EnqueueAsync(
                 () => UnderlyingCollection.Upsert(id, entity));
         }
     }

--- a/litedbasync/Collections/Upsert.cs
+++ b/litedbasync/Collections/Upsert.cs
@@ -10,11 +10,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpsertAsync(T entity)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Upsert(entity));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Upsert(entity));
         }
 
         /// <summary>
@@ -22,11 +19,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> UpsertAsync(IEnumerable<T> entities)
         {
-            var tcs = new TaskCompletionSource<int>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Upsert(entities));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Upsert(entities));
         }
 
         /// <summary>
@@ -34,11 +28,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> UpsertAsync(BsonValue id, T entity)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Database.Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingCollection.Upsert(id, entity));
-            });
-            return tcs.Task;
+            return Database.Enqueue(
+                () => UnderlyingCollection.Upsert(id, entity));
         }
     }
 }

--- a/litedbasync/LiteAsyncDelegate.cs
+++ b/litedbasync/LiteAsyncDelegate.cs
@@ -1,4 +1,4 @@
 namespace LiteDB.Async
 {
-    internal delegate void LiteAsyncDelegate();
+    internal delegate T LiteAsyncDelegate<out T>();
 }

--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -13,7 +13,7 @@ namespace LiteDB.Async
         private readonly Thread _backgroundThread;
         private readonly SemaphoreSlim _newTaskArrived = new SemaphoreSlim(initialCount: 0, maxCount: int.MaxValue);
         private readonly CancellationTokenSource _shouldTerminate = new CancellationTokenSource();
-        private readonly ConcurrentQueue<LiteAsyncDelegate> _queue = new ConcurrentQueue<LiteAsyncDelegate>();
+        private readonly ConcurrentQueue<Action> _queue = new ConcurrentQueue<Action>();
         private readonly bool _disposeOfWrappedDatabase = true;
         private static HashSet<ILiteDatabase> _wrappedDatabases = new HashSet<ILiteDatabase>();
         private static object _hashSetLock = new object();
@@ -132,13 +132,15 @@ namespace LiteDB.Async
             }
         }
 
-        internal void Enqueue<T>(TaskCompletionSource<T> tcs, LiteAsyncDelegate function)
+        internal Task<T> Enqueue<T>(LiteAsyncDelegate<T> function)
         {
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             void Function()
             {
                 try
                 {
-                    function();
+                    tcs.SetResult(function());
                 }
                 catch (Exception ex)
                 {
@@ -148,6 +150,7 @@ namespace LiteDB.Async
 
             _queue.Enqueue(Function);
             _newTaskArrived.Release();
+            return tcs.Task;
         }
 
         #region Collections
@@ -208,11 +211,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> BeginTransAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.BeginTrans());
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.BeginTrans());
         }
 
         /// <summary>
@@ -220,11 +220,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> CommitAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.Commit());
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.Commit());
         }
 
         /// <summary>
@@ -232,11 +229,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> RollbackAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.Rollback());
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.Rollback());
         }
 
         #endregion
@@ -247,11 +241,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> PragmaAsync(string name)
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.Pragma(name));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.Pragma(name));
         }
 
         /// <summary>
@@ -259,11 +250,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> PragmaAsync(string name, BsonValue value)
         {
-            var tcs = new TaskCompletionSource<BsonValue>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.Pragma(name, value));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.Pragma(name, value));
         }
         #endregion
 
@@ -274,11 +262,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<string>> GetCollectionNamesAsync()
         {
-            var tcs = new TaskCompletionSource<IEnumerable<string>>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.GetCollectionNames());
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.GetCollectionNames());
         }
 
         /// <summary>
@@ -286,11 +271,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> CollectionExistsAsync(string name)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.CollectionExists(name));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.CollectionExists(name));
         }
 
         /// <summary>
@@ -298,11 +280,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DropCollectionAsync(string name)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.DropCollection(name));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.DropCollection(name));
         }
 
         /// <summary>
@@ -310,11 +289,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> RenameCollectionAsync(string oldName, string newName)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.RenameCollection(oldName, newName));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.RenameCollection(oldName, newName));
         }
 
         #endregion
@@ -326,12 +302,11 @@ namespace LiteDB.Async
         /// </summary>
         public Task CheckpointAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            Enqueue(tcs, () => {
+            return Enqueue(() =>
+            {
                 UnderlyingDatabase.Checkpoint();
-                tcs.SetResult(true);
+                return true;
             });
-            return tcs.Task;
         }
 
         /// <summary>
@@ -339,11 +314,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> RebuildAsync(RebuildOptions options = null)
         {
-            var tcs = new TaskCompletionSource<long>();
-            Enqueue(tcs, () => {
-                tcs.SetResult(UnderlyingDatabase.Rebuild(options));
-            });
-            return tcs.Task;
+            return Enqueue(
+                () => UnderlyingDatabase.Rebuild(options));
         }
 
         #endregion

--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -329,10 +329,7 @@ namespace LiteDB.Async
                     _shouldTerminate.Cancel();
                     
                     // give the thread 5 seconds to exit... must not block forever here
-                    if (!_backgroundThread.Join(TimeSpan.FromSeconds(5)))
-                    {
-                        var tooslow = true;
-                    }
+                    _backgroundThread.Join(TimeSpan.FromSeconds(5));
                 }
                 lock(_hashSetLock) {
                     _wrappedDatabases.Remove(UnderlyingDatabase);

--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -357,7 +357,10 @@ namespace LiteDB.Async
                     _shouldTerminate.Cancel();
                     
                     // give the thread 5 seconds to exit... must not block forever here
-                    _backgroundThread.Join(TimeSpan.FromSeconds(5));
+                    if (!_backgroundThread.Join(TimeSpan.FromSeconds(5)))
+                    {
+                        var tooslow = true;
+                    }
                 }
                 lock(_hashSetLock) {
                     _wrappedDatabases.Remove(UnderlyingDatabase);

--- a/litedbasync/LiteDatabaseAsync.cs
+++ b/litedbasync/LiteDatabaseAsync.cs
@@ -132,7 +132,7 @@ namespace LiteDB.Async
             }
         }
 
-        internal Task<T> Enqueue<T>(LiteAsyncDelegate<T> function)
+        internal Task<T> EnqueueAsync<T>(LiteAsyncDelegate<T> function)
         {
             var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -211,7 +211,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> BeginTransAsync()
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.BeginTrans());
         }
 
@@ -220,7 +220,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> CommitAsync()
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.Commit());
         }
 
@@ -229,7 +229,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> RollbackAsync()
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.Rollback());
         }
 
@@ -241,7 +241,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> PragmaAsync(string name)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.Pragma(name));
         }
 
@@ -250,7 +250,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<BsonValue> PragmaAsync(string name, BsonValue value)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.Pragma(name, value));
         }
         #endregion
@@ -262,7 +262,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<string>> GetCollectionNamesAsync()
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.GetCollectionNames());
         }
 
@@ -271,7 +271,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> CollectionExistsAsync(string name)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.CollectionExists(name));
         }
 
@@ -280,7 +280,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DropCollectionAsync(string name)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.DropCollection(name));
         }
 
@@ -289,7 +289,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> RenameCollectionAsync(string oldName, string newName)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.RenameCollection(oldName, newName));
         }
 
@@ -302,7 +302,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task CheckpointAsync()
         {
-            return Enqueue(() =>
+            return EnqueueAsync(() =>
             {
                 UnderlyingDatabase.Checkpoint();
                 return true;
@@ -314,7 +314,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> RebuildAsync(RebuildOptions options = null)
         {
-            return Enqueue(
+            return EnqueueAsync(
                 () => UnderlyingDatabase.Rebuild(options));
         }
 

--- a/litedbasync/LiteQueryableAsync.cs
+++ b/litedbasync/LiteQueryableAsync.cs
@@ -230,11 +230,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<BsonDocument>> ToDocumentsAsync()
         {
-            var tcs = new TaskCompletionSource<IEnumerable<BsonDocument>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.ToDocuments());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.ToDocuments());
         }
 
         /// <summary>
@@ -242,11 +239,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> ToEnumerableAsync()
         {
-            var tcs = new TaskCompletionSource<IEnumerable<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.ToEnumerable());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.ToEnumerable());
         }
 
         /// <summary>
@@ -254,11 +248,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<List<T>> ToListAsync()
         {
-            var tcs = new TaskCompletionSource<List<T>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.ToList());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.ToList());
         }
 
         /// <summary>
@@ -266,11 +257,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T[]> ToArrayAsync()
         {
-            var tcs = new TaskCompletionSource<T[]>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.ToArray());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.ToArray());
         }
 
         /// <summary>
@@ -296,11 +284,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> SingleAsync()
         {
-            var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.Single());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.Single());
         }
 
         /// <summary>
@@ -308,11 +293,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> SingleOrDefaultAsync()
         {
-            var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.SingleOrDefault());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.SingleOrDefault());
         }
 
         /// <summary>
@@ -320,11 +302,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FirstAsync()
         {
-            var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.First());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.First());
         }
 
         /// <summary>
@@ -332,11 +311,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FirstOrDefaultAsync()
         {
-            var tcs = new TaskCompletionSource<T>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.FirstOrDefault());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.FirstOrDefault());
         }
 
         #endregion
@@ -348,11 +324,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync()
         {
-            var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.Count());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.Count());
         }
 
         /// <summary>
@@ -360,11 +333,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync()
         {
-            var tcs = new TaskCompletionSource<long>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.LongCount());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.LongCount());
         }
 
         /// <summary>
@@ -372,11 +342,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync()
         {
-            var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.Exists());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.Exists());
         }
 
         #endregion
@@ -385,11 +352,8 @@ namespace LiteDB.Async
 
         public Task<int> IntoAsync(string newCollection, BsonAutoId autoId = BsonAutoId.ObjectId)
         {
-            var tcs = new TaskCompletionSource<int>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedQuery.Into(newCollection, autoId));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedQuery.Into(newCollection, autoId));
         }
 
         #endregion

--- a/litedbasync/LiteQueryableAsync.cs
+++ b/litedbasync/LiteQueryableAsync.cs
@@ -230,7 +230,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<BsonDocument>> ToDocumentsAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.ToDocuments());
         }
 
@@ -239,7 +239,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<T>> ToEnumerableAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.ToEnumerable());
         }
 
@@ -248,7 +248,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<List<T>> ToListAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.ToList());
         }
 
@@ -257,7 +257,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T[]> ToArrayAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.ToArray());
         }
 
@@ -284,7 +284,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> SingleAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.Single());
         }
 
@@ -293,7 +293,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> SingleOrDefaultAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.SingleOrDefault());
         }
 
@@ -302,7 +302,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FirstAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.First());
         }
 
@@ -311,7 +311,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<T> FirstOrDefaultAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.FirstOrDefault());
         }
 
@@ -324,7 +324,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<int> CountAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.Count());
         }
 
@@ -333,7 +333,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<long> LongCountAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.LongCount());
         }
 
@@ -342,7 +342,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.Exists());
         }
 
@@ -352,7 +352,7 @@ namespace LiteDB.Async
 
         public Task<int> IntoAsync(string newCollection, BsonAutoId autoId = BsonAutoId.ObjectId)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedQuery.Into(newCollection, autoId));
         }
 

--- a/litedbasync/LiteStorageAsync.cs
+++ b/litedbasync/LiteStorageAsync.cs
@@ -22,11 +22,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> FindByIdAsync(TFileId id)
         {
-            var tcs = new TaskCompletionSource<LiteFileInfo<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.FindById(id));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.FindById(id));
         }
 
         /// <summary>
@@ -34,11 +31,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(BsonExpression predicate)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<LiteFileInfo<TFileId>>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Find(predicate));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Find(predicate));
         }
 
         /// <summary>
@@ -46,11 +40,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(string predicate, BsonDocument parameters)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<LiteFileInfo<TFileId>>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Find(predicate, parameters));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Find(predicate, parameters));
         }
 
         /// <summary>
@@ -58,11 +49,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(string predicate, params BsonValue[] args)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<LiteFileInfo<TFileId>>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Find(predicate, args));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Find(predicate, args));
         }
 
         /// <summary>
@@ -70,11 +58,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate)
         {
-            var tcs = new TaskCompletionSource<IEnumerable<LiteFileInfo<TFileId>>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Find(predicate));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Find(predicate));
         }
 
         /// <summary>
@@ -82,11 +67,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAllAsync()
         {
-            var tcs = new TaskCompletionSource<IEnumerable<LiteFileInfo<TFileId>>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.FindAll());
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.FindAll());
         }
 
         /// <summary>
@@ -94,11 +76,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(TFileId id)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Exists(id));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Exists(id));
         }
 
         /// <summary>
@@ -106,11 +85,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileStream<TFileId>> OpenWriteAsync(TFileId id, string filename, BsonDocument metadata = null)
         {
-            var tcs = new TaskCompletionSource<LiteFileStream<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.OpenWrite(id, filename, metadata));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.OpenWrite(id, filename, metadata));
         }
 
         /// <summary>
@@ -118,11 +94,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> UploadAsync(TFileId id, string filename, Stream stream, BsonDocument metadata = null)
         {
-            var tcs = new TaskCompletionSource<LiteFileInfo<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Upload(id, filename, stream, metadata));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Upload(id, filename, stream, metadata));
         }
 
         /// <summary>
@@ -130,11 +103,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> UploadAsync(TFileId id, string filename)
         {
-            var tcs = new TaskCompletionSource<LiteFileInfo<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Upload(id, filename));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Upload(id, filename));
         }
 
         /// <summary>
@@ -142,11 +112,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> SetMetadataAsync(TFileId id, BsonDocument metadata)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.SetMetadata(id, metadata));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.SetMetadata(id, metadata));
         }
 
         /// <summary>
@@ -154,11 +121,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileStream<TFileId>> OpenReadAsync(TFileId id)
         {
-            var tcs = new TaskCompletionSource<LiteFileStream<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.OpenRead(id));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.OpenRead(id));
         }
 
         /// <summary>
@@ -166,11 +130,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> DownloadAsync(TFileId id, Stream stream)
         {
-            var tcs = new TaskCompletionSource<LiteFileInfo<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Download(id, stream));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Download(id, stream));
         }
 
         /// <summary>
@@ -178,11 +139,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> DownloadAsync(TFileId id, string filename, bool overwritten)
         {
-            var tcs = new TaskCompletionSource<LiteFileInfo<TFileId>>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Download(id, filename, overwritten));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Download(id, filename, overwritten));
         }
 
         /// <summary>
@@ -190,11 +148,8 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DeleteAsync(TFileId id)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            _liteDatabaseAsync.Enqueue(tcs, () => {
-                tcs.SetResult(_wrappedStorage.Delete(id));
-            });
-            return tcs.Task;
+            return _liteDatabaseAsync.Enqueue(
+                () => _wrappedStorage.Delete(id));
         }
     }
 }

--- a/litedbasync/LiteStorageAsync.cs
+++ b/litedbasync/LiteStorageAsync.cs
@@ -22,7 +22,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> FindByIdAsync(TFileId id)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.FindById(id));
         }
 
@@ -31,7 +31,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(BsonExpression predicate)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Find(predicate));
         }
 
@@ -40,7 +40,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(string predicate, BsonDocument parameters)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Find(predicate, parameters));
         }
 
@@ -49,7 +49,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(string predicate, params BsonValue[] args)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Find(predicate, args));
         }
 
@@ -58,7 +58,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAsync(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Find(predicate));
         }
 
@@ -67,7 +67,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<IEnumerable<LiteFileInfo<TFileId>>> FindAllAsync()
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.FindAll());
         }
 
@@ -76,7 +76,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> ExistsAsync(TFileId id)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Exists(id));
         }
 
@@ -85,7 +85,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileStream<TFileId>> OpenWriteAsync(TFileId id, string filename, BsonDocument metadata = null)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.OpenWrite(id, filename, metadata));
         }
 
@@ -94,7 +94,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> UploadAsync(TFileId id, string filename, Stream stream, BsonDocument metadata = null)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Upload(id, filename, stream, metadata));
         }
 
@@ -103,7 +103,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> UploadAsync(TFileId id, string filename)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Upload(id, filename));
         }
 
@@ -112,7 +112,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> SetMetadataAsync(TFileId id, BsonDocument metadata)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.SetMetadata(id, metadata));
         }
 
@@ -121,7 +121,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileStream<TFileId>> OpenReadAsync(TFileId id)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.OpenRead(id));
         }
 
@@ -130,7 +130,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> DownloadAsync(TFileId id, Stream stream)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Download(id, stream));
         }
 
@@ -139,7 +139,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<LiteFileInfo<TFileId>> DownloadAsync(TFileId id, string filename, bool overwritten)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Download(id, filename, overwritten));
         }
 
@@ -148,7 +148,7 @@ namespace LiteDB.Async
         /// </summary>
         public Task<bool> DeleteAsync(TFileId id)
         {
-            return _liteDatabaseAsync.Enqueue(
+            return _liteDatabaseAsync.EnqueueAsync(
                 () => _wrappedStorage.Delete(id));
         }
     }

--- a/litedbasynctest/BackgroundThreadTest.cs
+++ b/litedbasynctest/BackgroundThreadTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Xunit;
 using LiteDB.Async;
 using System.IO;
@@ -21,6 +22,24 @@ namespace Tests.LiteDB.Async
                 
             }
             File.Delete(databasePath);
+        }
+
+        [Fact]
+        public async Task TestCanDisposeDatabaseTimely()
+        {
+            string databasePath = Path.Combine(Path.GetTempPath(),
+                "litedbn-async-testing-" + Path.GetRandomFileName() + ".db");
+            var db = new LiteDatabaseAsync(databasePath);
+
+            // Ensure to do some stuff to open the database
+            var collection = db.GetCollection<SimplePerson>();
+            await collection.InsertAsync(new SimplePerson()).ConfigureAwait(false);
+
+            var stopwatch = Stopwatch.StartNew();
+            db.Dispose();
+            stopwatch.Stop();
+
+            Assert.InRange(stopwatch.Elapsed.TotalSeconds, 0, 4.99);
         }
 
         [Fact]

--- a/litedbasynctest/BackgroundThreadTest.cs
+++ b/litedbasynctest/BackgroundThreadTest.cs
@@ -43,13 +43,16 @@ namespace Tests.LiteDB.Async
         }
 
         [Fact]
-        public void TestOpeningDatabaseASecondTimeCausesAnException()
+        public async Task TestOpeningDatabaseASecondTimeCausesAnException()
         {
             string databasePath = Path.Combine(Path.GetTempPath(), "litedbn-async-testing-" + Path.GetRandomFileName() + ".db");
             using(var db1 = new LiteDatabaseAsync(databasePath))
             {
-                Assert.Throws<IOException>(() => {
-                    var db2 = new LiteDatabaseAsync(databasePath);
+                await db1.GetCollection<SimplePerson>().InsertAsync(new SimplePerson());
+                
+                Assert.ThrowsAsync<IOException>(async () => {
+                    using var db2 = new LiteDatabaseAsync(databasePath);
+                    await db2.GetCollection<SimplePerson>().InsertAsync(new SimplePerson());
                 });
             }
             File.Delete(databasePath);

--- a/litedbasynctest/engine/Transaction_Tests.cs
+++ b/litedbasynctest/engine/Transaction_Tests.cs
@@ -98,9 +98,9 @@ namespace Tests.LiteDB.Async
                     await asyncPerson.InsertAsync(data2);
 
                     taskBSemaphore.Release();
-                    taskASemaphore.Wait();
+                    await taskASemaphore.WaitAsync();
 
-                    var count = person.Count();
+                    var count = await asyncPerson.CountAsync();
 
                     count.Should().Be(data1.Length + data2.Length);
 


### PR DESCRIPTION
Fix for #18 

This ensures that `TaskCreationOptions.RunContinuationsAsynchronously` is passed to every `TaskCompletionSource` to ensure the completion is not running on the databases background thread.

Also simplifies all async wrappers by centralizing creation of the `TaskCompletionSource` into `Enqueue`