### PR TITLE
Bump LiteDB from 5.0.14 to 5.0.15

### DIFF
--- a/litedbasync/litedbasync.csproj
+++ b/litedbasync/litedbasync.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.14" />
+    <PackageReference Include="LiteDB" Version="5.0.15" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
New LiteDB version got released about 2 weeks ago.
https://github.com/mbdavid/LiteDB/releases/tag/v5.0.15

Also noticed that 4 unit tests are failing apparently, but isn't related to this version bump.
![image](https://user-images.githubusercontent.com/10922456/210750454-4fc641c1-344e-4458-b010-5470c1f09e22.png)

